### PR TITLE
Removed the need to return `view.to_s` in components

### DIFF
--- a/spec/motion/html_page_spec.cr
+++ b/spec/motion/html_page_spec.cr
@@ -24,7 +24,7 @@ describe Motion::Base do
 
   describe "HTML escaping" do
     it "escapes text" do
-      UnsafePage.new.render.should eq "&lt;script&gt;not safe&lt;/span&gt;"
+      fetch_view(UnsafePage).should eq "&lt;script&gt;not safe&lt;/span&gt;"
     end
 
     it "escapes HTML attributes" do
@@ -37,7 +37,7 @@ describe Motion::Base do
   end
 
   it "renders complicated HTML syntax" do
-    TestRender.new.render.should be_a(String)
+    TestRender.new.render.should be_a(Nil)
   end
 
   it "can render raw strings" do
@@ -48,30 +48,32 @@ describe Motion::Base do
 
   describe "can be used to render layouts" do
     it "renders layouts and needs" do
-      InnerPage.new(foo: "bar").render.should contain %(<title>A great title</title>)
-      InnerPage.new(foo: "bar").render.should contain %(<body>Inner textbar</body>)
+      c = InnerPage.new(foo: "bar")
+      c.render
+      c.view.to_s.should contain %(<title>A great title</title>)
+      c.view.to_s.should contain %(<body>Inner textbar</body>)
     end
   end
 
   describe "props with defaults" do
     it "allows default values to needs" do
-      LessNeedyDefaultsPage.new.render.should contain %(<div>string default</div>)
+      fetch_view(LessNeedyDefaultsPage).should contain %(<div>string default</div>)
     end
 
     it "allows false as default value to needs" do
-      LessNeedyDefaultsPage.new.render.should contain %(<div>bool default</div>)
+      fetch_view(LessNeedyDefaultsPage).should contain %(<div>bool default</div>)
     end
 
     it "allows nil as default value to needs" do
-      LessNeedyDefaultsPage.new.render.should contain %(<div>nil default</div>)
+      fetch_view(LessNeedyDefaultsPage).should contain %(<div>nil default</div>)
     end
 
     it "infers the default value from nilable needs" do
-      LessNeedyDefaultsPage.new.render.should contain %(<div>inferred nil default</div>)
+      fetch_view(LessNeedyDefaultsPage).should contain %(<div>inferred nil default</div>)
     end
 
     it "infers the default value from nilable needs" do
-      LessNeedyDefaultsPage.new.render.should contain %(<div>inferred nil default 2</div>)
+      fetch_view(LessNeedyDefaultsPage).should contain %(<div>inferred nil default 2</div>)
     end
   end
 
@@ -84,4 +86,10 @@ private def view
   TestRender.new.tap do |page|
     yield page
   end.view.to_s
+end
+
+private def fetch_view(klass)
+  c = klass.new
+  c.render
+  c.view.to_s
 end

--- a/spec/motion/html_transformer_spec.cr
+++ b/spec/motion/html_transformer_spec.cr
@@ -3,7 +3,9 @@ require "myhtml"
 
 describe Motion::HTMLTransformer do
   it "can transform markup" do
-    MotionRender.new.render.includes?("motion-state").should be_true
+    c = MotionRender.new
+    c.render
+    c.view.to_s.includes?("motion-state").should be_true
   end
 
   it "throws error when component has multiple roots" do

--- a/spec/motion/serializer_spec.cr
+++ b/spec/motion/serializer_spec.cr
@@ -2,7 +2,9 @@ require "../spec_helper"
 
 describe Motion::Serializer do
   it "can deserialize component" do
-    fragment = Myhtml::Parser.new(MotionRender.new.render)
+    c = MotionRender.new
+    c.render
+    fragment = Myhtml::Parser.new(c.view.to_s)
     node_with_state = fragment.body!.children.to_a[0]
     state = node_with_state.attribute_by("data-motion-state")
 

--- a/spec/support/model_fixtures.cr
+++ b/spec/support/model_fixtures.cr
@@ -1,7 +1,6 @@
 class TestRender < Motion::Base
-  def render : String
+  def render
     render_complicated_html
-    view.to_s
   end
 
   private def render_complicated_html
@@ -27,7 +26,6 @@ end
 class UnsafePage < Motion::Base
   def render
     text "<script>not safe</span>"
-    view.to_s
   end
 end
 
@@ -38,7 +36,6 @@ abstract class MainLayout < Motion::Base
     body do
       inner
     end
-    view.to_s
   end
 
   abstract def inner
@@ -93,7 +90,6 @@ class MotionRender < Motion::Base
 
   def render
     m MotionMount
-    view.to_s
   end
 end
 
@@ -113,7 +109,6 @@ class MotionMount < Motion::Base
         h2 @count.to_s
       end
     end
-    view.to_s
   end
 end
 
@@ -138,6 +133,5 @@ class UnsafeMultipleRootsMount < Motion::Base
     div do
       h1 "hi"
     end
-    view.to_s
   end
 end

--- a/src/motion/base.cr
+++ b/src/motion/base.cr
@@ -57,6 +57,7 @@ abstract class Motion::Base
   def rerender
     self.view = IO::Memory.new
     render
+    view.to_s
   end
 
   # :nodoc:

--- a/src/motion/mount_component.cr
+++ b/src/motion/mount_component.cr
@@ -50,7 +50,8 @@ module Motion::MountComponent
   end
 
   private def render_and_transform(component : Motion::Base)
-    html = component.render
+    component.render
+    html = component.view.to_s
 
     if component.motion_component
       html = Motion.html_transformer.add_state_to_html(component, html)


### PR DESCRIPTION
Motion rendering takes care of this now. Users can just focus on business logic in the render method instead of returning the actual view